### PR TITLE
Replace mock users with GitHub users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.log
+.firebase/

--- a/src/app/login-staff/page.tsx
+++ b/src/app/login-staff/page.tsx
@@ -49,11 +49,14 @@ export default function StaffLoginPage() {
           </CardHeader>
           <CardContent>
             <div className="flex flex-col gap-6">
-              <StaffPicker onSelect={(u) => setSelected(u)} />
+              <div className="space-y-2">
+                <div className="text-sm text-muted-foreground">Select your user</div>
+                <StaffPicker onSelect={(u) => setSelected(u)} selectedId={selected?.id} />
+              </div>
 
               <form ref={formRef} action={dispatch} className="space-y-4">
                 <input type="hidden" name="pin" value={pin} />
-                <PinPad pin={pin} setPin={setPin} isPending={pending} />
+                <PinPad pin={pin} setPin={setPin} isPending={pending} disabled={!selected} />
                 {selected && (
                   <div className="text-sm text-muted-foreground text-center">Logging in as <span className="font-medium">{selected.name || selected.username}</span></div>
                 )}

--- a/src/app/login-staff/page.tsx
+++ b/src/app/login-staff/page.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PinPad } from '@/components/pin-pad';
-
+import StaffPicker, { type StaffListUser } from '@/components/staff-picker';
 
 export default function StaffLoginPage() {
   const initialState: StaffLoginState = { error: null };
@@ -17,46 +17,53 @@ export default function StaffLoginPage() {
   const { pending } = useFormStatus();
 
   const [pin, setPin] = useState('');
+  const [selected, setSelected] = useState<StaffListUser | null>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
-  // Automatically submit the form when PIN is 4 digits
   useEffect(() => {
     if (pin.length === 4 && formRef.current && !pending) {
-        formRef.current.requestSubmit();
+      formRef.current.requestSubmit();
     }
   }, [pin, pending]);
 
-  // Clear PIN on error
   useEffect(() => {
     if (state.error) {
-        setPin('');
+      setPin('');
     }
-  }, [state.error])
+  }, [state.error]);
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-4 bg-background">
-      <div className="w-full max-w-sm">
-        <Button variant="ghost" asChild className="absolute top-4 left-4">
+    <main className="flex min-h-screen flex-col items-center px-4 py-6 bg-background">
+      <div className="w-full max-w-4xl">
+        <Button variant="ghost" asChild className="mb-4">
           <Link href="/">
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Home
           </Link>
         </Button>
-        <Card>
+
+        <Card className="overflow-hidden">
           <CardHeader className="text-center">
             <CardTitle className="text-2xl font-headline text-primary">Staff Login</CardTitle>
-            <CardDescription>Enter your 4-digit PIN to continue.</CardDescription>
+            <CardDescription>Select your user, then enter your 4-digit PIN.</CardDescription>
           </CardHeader>
           <CardContent>
-            <form ref={formRef} action={dispatch} className="space-y-6">
-              <input type="hidden" name="pin" value={pin} />
-              <PinPad pin={pin} setPin={setPin} isPending={pending} />
-              {state.error && (
-                 <Alert variant="destructive">
-                   <AlertDescription>{state.error}</AlertDescription>
-                 </Alert>
-              )}
-            </form>
+            <div className="flex flex-col gap-6">
+              <StaffPicker onSelect={(u) => setSelected(u)} />
+
+              <form ref={formRef} action={dispatch} className="space-y-4">
+                <input type="hidden" name="pin" value={pin} />
+                <PinPad pin={pin} setPin={setPin} isPending={pending} />
+                {selected && (
+                  <div className="text-sm text-muted-foreground text-center">Logging in as <span className="font-medium">{selected.name || selected.username}</span></div>
+                )}
+                {state.error && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{state.error}</AlertDescription>
+                  </Alert>
+                )}
+              </form>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/pin-pad.tsx
+++ b/src/components/pin-pad.tsx
@@ -9,21 +9,36 @@ type PinPadProps = {
   pin: string;
   setPin: Dispatch<SetStateAction<string>>;
   isPending: boolean;
+  disabled?: boolean;
 };
 
-export function PinPad({ pin, setPin, isPending }: PinPadProps) {
+export function PinPad({ pin, setPin, isPending, disabled = false }: PinPadProps) {
   const handleNumberClick = (num: string) => {
+    if (disabled) return;
     if (pin.length < 4) {
       setPin((prev) => prev + num);
     }
   };
 
   const handleBackspace = () => {
+    if (disabled) return;
     setPin((prev) => prev.slice(0, -1));
   };
 
+  const dots = [0, 1, 2, 3];
+
   return (
     <div className="flex flex-col items-center gap-4">
+        <div className="flex items-center gap-2" aria-label="PIN progress">
+          {dots.map((i) => (
+            <div
+              key={i}
+              className={
+                'h-2.5 w-2.5 rounded-full ' + (i < pin.length ? 'bg-primary' : 'bg-muted-foreground/30')
+              }
+            />
+          ))}
+        </div>
         <Input
             type="password"
             value={pin}
@@ -32,6 +47,7 @@ export function PinPad({ pin, setPin, isPending }: PinPadProps) {
             maxLength={4}
             placeholder="••••"
             aria-label="PIN input"
+            disabled={disabled}
         />
         <div className="grid grid-cols-3 gap-2">
             {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((num) => (
@@ -41,7 +57,7 @@ export function PinPad({ pin, setPin, isPending }: PinPadProps) {
                 variant="outline"
                 className="h-16 w-16 text-2xl"
                 onClick={() => handleNumberClick(num.toString())}
-                disabled={isPending}
+                disabled={isPending || disabled}
             >
                 {num}
             </Button>
@@ -52,11 +68,11 @@ export function PinPad({ pin, setPin, isPending }: PinPadProps) {
                 variant="outline"
                 className="h-16 w-16 text-2xl"
                 onClick={() => handleNumberClick('0')}
-                disabled={isPending}
+                disabled={isPending || disabled}
             >
             0
             </Button>
-            <Button type="button" variant="outline" className="h-16 w-16" onClick={handleBackspace} disabled={isPending}>
+            <Button type="button" variant="outline" className="h-16 w-16" onClick={handleBackspace} disabled={isPending || disabled}>
                 <X className="h-8 w-8" />
             </Button>
         </div>

--- a/src/components/staff-picker.tsx
+++ b/src/components/staff-picker.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { db } from '@/lib/firebaseConfig';
+import { collection, getDocs, orderBy, query, where } from 'firebase/firestore';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+export type StaffListUser = {
+  id: string;
+  name: string;
+  username?: string | null;
+  role: string;
+  imageUrl?: string | null;
+};
+
+type StaffPickerProps = {
+  onSelect: (user: StaffListUser) => void;
+  className?: string;
+  includeAdmins?: boolean;
+};
+
+function getInitials(name?: string | null): string {
+  if (!name) return '';
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  return parts.map((p) => p[0]?.toUpperCase() ?? '').join('');
+}
+
+export default function StaffPicker({ onSelect, className, includeAdmins = false }: StaffPickerProps) {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [users, setUsers] = useState<StaffListUser[]>([]);
+  const [search, setSearch] = useState<string>('');
+
+  useEffect(() => {
+    let isMounted = true;
+    async function loadUsers() {
+      setLoading(true);
+      try {
+        const usersRef = collection(db, 'users');
+        // Only fetch active users. We avoid filtering by exposeOnPinLogin to be resilient to missing data.
+        const q = query(usersRef, where('active', '==', true), orderBy('name'));
+        const snap = await getDocs(q);
+        if (!isMounted) return;
+        const list: StaffListUser[] = snap.docs
+          .map((d) => {
+            const u = d.data() as any;
+            const role = String(u.role ?? '').toLowerCase();
+            if (!includeAdmins && role === 'admin') return null;
+            return {
+              id: d.id,
+              name: (u.name ?? u.displayName ?? u.username ?? '').toString(),
+              username: (u.username ?? null) as string | null,
+              role,
+              imageUrl: (u.imageUrl ?? null) as string | null,
+            } as StaffListUser;
+          })
+          .filter(Boolean) as StaffListUser[];
+        setUsers(list);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    }
+    void loadUsers();
+    return () => {
+      isMounted = false;
+    };
+  }, [includeAdmins]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return users;
+    return users.filter((u) =>
+      [u.name, u.username, u.role].some((v) => (v ?? '').toString().toLowerCase().includes(q))
+    );
+  }, [users, search]);
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <Input
+        placeholder="Search staff by name or username"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      {loading ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="h-24 rounded-lg bg-muted animate-pulse" />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="text-sm text-muted-foreground">No active users found.</div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+          {filtered.map((u) => (
+            <button
+              key={u.id}
+              type="button"
+              onClick={() => onSelect(u)}
+              className="group rounded-lg border bg-card hover:bg-accent/40 transition-colors p-3 text-left flex items-center gap-3"
+            >
+              {u.imageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={u.imageUrl}
+                  alt={u.name}
+                  className="h-10 w-10 rounded-full object-cover"
+                />
+              ) : (
+                <div className="h-10 w-10 rounded-full bg-primary/15 text-primary flex items-center justify-center font-semibold">
+                  {getInitials(u.name)}
+                </div>
+              )}
+              <div className="min-w-0">
+                <div className="truncate font-medium">{u.name || u.username}</div>
+                <div className="text-xs text-muted-foreground capitalize truncate">{u.role}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/staff-picker.tsx
+++ b/src/components/staff-picker.tsx
@@ -18,6 +18,7 @@ type StaffPickerProps = {
   onSelect: (user: StaffListUser) => void;
   className?: string;
   includeAdmins?: boolean;
+  selectedId?: string;
 };
 
 function getInitials(name?: string | null): string {
@@ -26,7 +27,7 @@ function getInitials(name?: string | null): string {
   return parts.map((p) => p[0]?.toUpperCase() ?? '').join('');
 }
 
-export default function StaffPicker({ onSelect, className, includeAdmins = false }: StaffPickerProps) {
+export default function StaffPicker({ onSelect, className, includeAdmins = false, selectedId }: StaffPickerProps) {
   const [loading, setLoading] = useState<boolean>(true);
   const [users, setUsers] = useState<StaffListUser[]>([]);
   const [search, setSearch] = useState<string>('');
@@ -96,7 +97,10 @@ export default function StaffPicker({ onSelect, className, includeAdmins = false
               key={u.id}
               type="button"
               onClick={() => onSelect(u)}
-              className="group rounded-lg border bg-card hover:bg-accent/40 transition-colors p-3 text-left flex items-center gap-3"
+              className={cn(
+                "group rounded-lg border bg-card hover:bg-accent/40 transition-colors p-3 text-left flex items-center gap-3",
+                selectedId === u.id && "ring-2 ring-primary/60 bg-accent/30"
+              )}
             >
               {u.imageUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION
Reworked staff login UI for better user experience and integrated real Firestore users.

The previous split-screen login layout was not preferred. This PR unifies the login screen into a single view with a searchable staff grid at the top and a PIN pad below, pulling active user data directly from Firestore instead of relying on mock data.

---
<a href="https://cursor.com/background-agent?bcId=bc-4172821f-04ff-46ca-addc-c7c3ab295437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4172821f-04ff-46ca-addc-c7c3ab295437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

